### PR TITLE
remove unuse comma_expression

### DIFF
--- a/tuibox.h
+++ b/tuibox.h
@@ -49,7 +49,7 @@
 
 #define vec_push(v, val)\
   ( vec_expand_(vec_unpack_(v)) ? -1 :\
-    ((v)->data[(v)->length++] = (val), 0), 0 )
+    ((v)->data[(v)->length++] = (val), 0) )
 
 
 #define vec_pop(v)\


### PR DESCRIPTION
I am very grateful to the author for writing this library. I encountered a small error when I tried to use zig to import this header file (caused by the use of the ternary operator and comma expressions together. I have reported the problem to ziglang). And I checked the source code and found that the comma expression of the `vec_push` macro was not used, so I removed it (removing this part has no impact on the entire code), and this allows zig to smoothly import the header file